### PR TITLE
Update `NodeStatus` for `ephemeral` and `duration` props

### DIFF
--- a/node-red-types/func.d.ts
+++ b/node-red-types/func.d.ts
@@ -29,7 +29,11 @@ interface NodeStatus {
     /** The shape property can be: ring or dot */
     shape?: 'ring'|'dot'|AnyString;
     /** The text to display */
-    text?: string|boolean|number
+    text?: string|boolean|number;
+    /** Delay in milliseconds before clearing the status or restoring the previous non visual status if {@link ephemeral} is enabled */
+    duration?: number;
+    /** If enabled, the status is visual only; it will not trigger `Status` nodes */
+    ephemeral?: boolean;
 }
 
 declare class node {

--- a/node-red-types/func.d.ts
+++ b/node-red-types/func.d.ts
@@ -13,6 +13,9 @@ declare const __msgid__:string;
 declare const util:typeof import('util')
 declare const promisify:typeof import('util').promisify
 
+/** Helper type to enable autocomplete of String */
+type AnyString = (string & {});
+
 /**
  * @typedef NodeStatus
  * @type {object}
@@ -22,9 +25,9 @@ declare const promisify:typeof import('util').promisify
  */
 interface NodeStatus {
     /** The fill property can be: red, green, yellow, blue or grey */
-    fill?: 'red'|'green'|'yellow'|'blue'|'grey'|string,
+    fill?: 'red'|'green'|'yellow'|'blue'|'grey'|AnyString;
     /** The shape property can be: ring or dot */
-    shape?: 'ring'|'dot'|string,
+    shape?: 'ring'|'dot'|AnyString;
     /** The text to display */
     text?: string|boolean|number
 }

--- a/node-red-types/func.d.ts
+++ b/node-red-types/func.d.ts
@@ -30,9 +30,9 @@ interface NodeStatus {
     shape?: 'ring'|'dot'|AnyString;
     /** The text to display */
     text?: string|boolean|number;
-    /** Delay in milliseconds before clearing the status or restoring the previous non visual status if {@link ephemeral} is enabled */
+    /** Delay in milliseconds before clearing the status or restoring the previous non visual status if `ephemeral` is enabled. */
     duration?: number;
-    /** If enabled, the status is visual only; it will not trigger `Status` nodes */
+    /** If enabled, the status is visual only; it will not trigger `Status` nodes. Default `duration` 5s. */
     ephemeral?: boolean;
 }
 


### PR DESCRIPTION
Follows https://github.com/node-red/node-red/pull/5331.

Update the `NodeStatus` interface to:

- Allow autocomplete of String

  <img width="640" height="108" alt="Capture d’écran 2025-10-27 à 20 43 54" src="https://github.com/user-attachments/assets/17a3e5a4-d812-4870-8e03-af037e27ddbe" />

- Add `duration` and `ephemeral` properties

NOTE: Merge only after the linked PR has been merged.